### PR TITLE
Fix bug on undefined hostname

### DIFF
--- a/blocklist.js
+++ b/blocklist.js
@@ -53,19 +53,20 @@ exports.urlAllowed = function(url){
     return false;
   }
   
-  // next check each sub-domain, skipping the final one since we just checked it above
-  var hostname_parts = url.hostname.split("."),
-		i = (hostname_parts[hostname_parts.length-2] == "co") ? 3 : 2, // ignore domains like co.uk
-    cur_domain;
-    
-	for(; i<= hostname_parts.length-1; i++){
-  		cur_domain = hostname_parts.slice(-1*i).join('.'); // first site.com, then www.site.com, etc.
-		if(domains.data.indexOf(cur_domain) != -1){
-			console.log("failed on subdomain ", cur_domain, domains.data);
-      		return false;
-    	}
+  if(url.hostname) {
+		// next check each sub-domain, skipping the final one since we just checked it above
+		var hostname_parts = url.hostname.split("."),
+			i = (hostname_parts[hostname_parts.length-2] == "co") ? 3 : 2, // ignore domains like co.uk
+			cur_domain;
+			
+		for(; i<= hostname_parts.length-1; i++){
+				cur_domain = hostname_parts.slice(-1*i).join('.'); // first site.com, then www.site.com, etc.
+			if(domains.data.indexOf(cur_domain) != -1){
+				console.log("failed on subdomain ", cur_domain, domains.data);
+						return false;
+				}
+		}
 	}
-  
   // lastly, go through each keyword in the list and check if it's in the url anywhere
   if(keywords.data.some(function(keyword){ 
   	if( url.href.indexOf(keyword) != -1 ){ 

--- a/server.js
+++ b/server.js
@@ -309,8 +309,10 @@ function proxy(request, response) {
 * Does not currently honor http / https only directives.
 */
 function getCookies(request, uri){
+  if( uri.hostname ) {
+    var hostname_parts = uri.hostname.split(".");
+  }
 	var cookies = "",
-		hostname_parts = uri.hostname.split("."),
 		i = (hostname_parts[hostname_parts.length-2] == "co") ? 3 : 2, // ignore domains like co.uk
 		cur_domain,
 		path_parts = uri.pathname.split("/"),	


### PR DESCRIPTION
This patch fixes a bug that makes node-unblocker crash when the url.hostname and uri.hostname variable is set to undefined.

It throws the error:
TypeError: Cannot call method 'split' of undefined
    at getCookies (/root/node-unblocker/server.js:313:33)
    at proxy (/root/node-unblocker/server.js:136:19)
    at Server.<anonymous> (/root/node-unblocker/server.js:65:10)
    at Server.emit (events.js:67:17)
    at HTTPParser.onIncoming (http.js:1123:12)
    at HTTPParser.onHeadersComplete (http.js:108:31)
    at Socket.ondata (http.js:1018:22)
    at Socket._onReadable (net.js:683:27)
    at IOWatcher.onReadable [as callback](net.js:177:10)

And then dies.
