### PR TITLE
Several regex fixes and code restructure for better css rewriting and ma...

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,18 +116,19 @@ var server = connect()
 }); // we'll start the server at the bottom of the file
 
 
-var portmap 		= {"http:":80,"https:":443},
-	re_abs_url 	= /("|'|=)(http:(\/\/|\\\/\\\/)|https:(\/\/|\\\/\\\/))/ig, // "http, 'http, or =http
+var portmap 			= {"http:":80,"https:":443},
+	re_abs_url 		= /("|'|=)(http:(\/\/|\\\/\\\/)|https:(\/\/|\\\/\\\/))/ig, // "http, 'http, or =http
 	re_abs_no_proto 	= /("|'|=)(\/\/\w)/ig, // matches //site.com style urls where the protocol is auto-sensed
-	re_rel_root = /((href|src|action)=['"]{0,1})(\/\w)/ig, // matches src="/asdf/asdf"
+	re_rel_root 		= /((href|src|action)=['"]{0,1})(\/\w)/ig, // matches src="/asdf/asdf"
 	// no need to match href="asdf/adf" relative links - those will work without modification
 	
-	re_css_abs = /(url\(\s*['"]{0,1})(http:(\/\/|\\\/\\\/)|https:(\/\/|\\\/\\\/)|\/\/)/ig, // matches url( http
-	re_css_rel_root = /(url\(\s*['"]{0,1})(\/\w)/ig, // matches url( /asdf/img.jpg
+	re_css_abs 		= /(url\(\s*['"]{0,1})(http:(\/\/|\\\/\\\/)|https:(\/\/|\\\/\\\/))/ig, // matches url( http
+	re_css_abs_no_proto 	= /(url\(\s*['"]{0,1})(\/\/\w)/ig,
+	re_css_rel_root 	= /(url\(\s*['"]{0,1})(\/\w)/ig, // matches url( /asdf/img.jpg
 	
 	// partial's dont cause anything to get changed, they just cause the packet to be buffered and rechecked
-	re_html_partial = /("|'|=|\(\s*)[ht]{1,3}$/ig, // ', ", or = followed by one to three h's and t's at the end of the line
-	re_css_partial = /(url\(\s*['"]{0,1})[ht]{1,3}$/ig; // above, but for url( htt
+	re_html_partial 	= /("|'|=|\(\s*)[ht]{1,3}$/ig, // ', ", or = followed by one to three h's and t's at the end of the line
+	re_css_partial 		= /(url\(\s*['"]{0,1})[ht]{1,3}$/ig; // above, but for url( htt
 
 // charset aliases which charset supported by native node.js
 var charset_aliases = {
@@ -297,6 +298,7 @@ function proxy(request, response) {
 			if(ct == 'text/css'){
 				console.log('running css rules');
 				chunk = chunk.replace(re_css_abs, "$1" + thisSite(request) + "/$2");
+				chunk = chunk.replace(re_css_abs_no_proto, "$1" + realURL + "/" + uri.protocol + "$2");
 				chunk = chunk.replace(re_css_rel_root, "$1" + thisSite(request) + "/" + uri.protocol + "//" + uri.hostname + "$2");			
 			} else {
 				// first replace any complete urls


### PR DESCRIPTION
...ke the </head> replace only affect html

Fix for regular expressions so it really makes sure that it's http(s):// since people could name a folder http on their server (http/myawesomefile.html). Shouldn't affect performance too much.

Also fixes the missing ["']{0,1} rules. Example where old CSS rule wouldn't apply:
url("http://media.onexamination.com/css/framework/fonts/fontawesome-webfont.eot?v=3.2.1");

The code restructure makes it a little faster parsing CSS since it doesn't have to run all the HTML rules.

Making the ROBOTS only affect html is a great idea since some JavaScript contains the </head> tag making it crash the JavaScript with the old code.
