### PR TITLE
Prevent urls with ?parameter=value to get slashed

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -41,7 +41,7 @@ function proxy(uri, request, response) {
     request.session = request.session || {};
 
     // redirect urls like /proxy/http://asdf.com to /proxy/http://asdf.com/ to make relative image paths work
-    if (uri.pathname == "/" && request.url.substr(-1) != "/") {
+    if (uri.pathname == "/" && request.url.substr(-1) != "/" && !(request.url.indexOf("?") !== -1)) {
         return response.redirectTo(request.url + "/");
     }
 


### PR DESCRIPTION
Adds a check that checks for question marks in the URL to prevent an additional slash to being added sometimes breaking the website.

Example URL that this would occur on before this fix: https://www.google.se/?parameter=value
