### PR TITLE
Add a 'strict-transport-security' remover

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -117,6 +117,11 @@ function proxy(uri, request, response) {
             cookies.set(request, uri, headers['set-cookie']);
             delete headers['set-cookie'];
         }
+        
+        // We don't want to send this to the client
+        if (headers['strict-transport-security']) {
+            delete headers['strict-transport-security'];
+        }
 
         //  fire off out (possibly modified) headers
         response.writeHead(remote_response.statusCode, headers);


### PR DESCRIPTION
Some HTTPS servers send a 'strict-transport-security' header, we don't want to pass this to the client.