### PR TITLE
Enable HPKP stripping

### DIFF
--- a/lib/hpkp.js
+++ b/lib/hpkp.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var debug = require('debug')('unblocker:hpkp');
+
+module.exports = function( /*config*/ ) {
+
+    function hpkp(data) {
+        // this could potentially block clients from using the proxy successfully.
+        if (data.headers['public-key-pins']) {
+            debug('deleting public-key-pins header');
+            delete data.headers['public-key-pins'];
+        }
+    }
+
+    return hpkp;
+};

--- a/lib/unblocker.js
+++ b/lib/unblocker.js
@@ -8,6 +8,7 @@ Unblocker.host = require('./host.js');
 Unblocker.referer = require('./referer.js');
 Unblocker.cookies = require('./cookies.js');
 Unblocker.hsts = require('./hsts.js');
+Unblocker.hpkp = require('./hpkp.js');
 Unblocker.redirects = require('./redirects.js');
 Unblocker.decompress = require('./decompress.js');
 Unblocker.charsets = require('./charsets.js');
@@ -52,6 +53,7 @@ function Unblocker(config) {
         var referer = Unblocker.referer(config);
         var cookies = Unblocker.cookies(config);
         var hsts = Unblocker.hsts(config);
+        var hpkp = Unblocker.hpkp(config);
         var redirects = Unblocker.redirects(config);
         var decompress = Unblocker.decompress(config);
         var charsets = Unblocker.charsets(config);
@@ -68,6 +70,7 @@ function Unblocker(config) {
 
         config.responseMiddleware = [
             hsts,
+            hpkp,
             redirects,
             decompress.handleResponse,
             charsets,

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,7 @@ Most of the internal functionality of the proxy is also implemented as middlewar
     Fixes the `Path` attribute of set-cookie headers to limit cookies to their "path" on the proxy (e.g. `Path=/proxy/http://example.com/`). 
     Also injects redirects to copy cookies from between protocoles and subdomains on a given domain.
 * **hsts**: Removes [Strict-Transport-Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) headers because they can leak to other sites and can break the proxy.
+* **hpkp**: Removes [Public-Key-Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) headers because they can leak to other sites and can break the proxy.
 * **redirects**: Rewrites urls in 3xx redirects to ensure they go through the proxy
 * **decompress**: Decompresses `Content-Encoding: gzip` responses and also tweaks request headers to ask for either gzip-only or no compression at all. (It will attempt to decompress `deflate` content, but there are some issues, so it does not advertise support for `deflate`.)
 * **charsets**: Converts the charset of responses to UTF-8 for safe string processing in node.js. Determines charset from headers or meta tags and rewrites all headers and meta tags in outgoing response.
@@ -208,6 +209,7 @@ var host = Unblocker.host(config);
 var referer = Unblocker.referer(config);
 var cookies = Unblocker.cookies(config);
 var hsts = Unblocker.hsts(config);
+var hpkp = Unblocker.hpkp(config);
 var redirects = Unblocker.redirects(config);
 var decompress = Unblocker.decompress(config);
 var charsets = Unblocker.charsets(config);
@@ -225,6 +227,7 @@ config.requestMiddleware = [
 
 config.responseMiddleware = [
     hsts,
+    hpkp,
     redirects,
     decompress.handleResponse,
     charsets,


### PR DESCRIPTION
Strips HPKP headers which could cause issues navigating the web in Unblocker.

GitHub uses HPKP.

Reference: https://developer.mozilla.org/en-US/docs/Web/Security/Public_Key_Pinning