### PR TITLE
Enable CSP stripping

### DIFF
--- a/lib/csp.js
+++ b/lib/csp.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var debug = require('debug')('unblocker:csp');
+
+module.exports = function( /*config*/ ) {
+
+    function csp(data) {
+        // not removing csp could potentially prevent clients from using the proxy successfully.
+        if (data.headers['content-security-policy']) {
+            debug('deleting content-security-policy header');
+            delete data.headers['content-security-policy'];
+        }
+    }
+
+    return csp;
+};

--- a/lib/unblocker.js
+++ b/lib/unblocker.js
@@ -9,6 +9,7 @@ Unblocker.referer = require('./referer.js');
 Unblocker.cookies = require('./cookies.js');
 Unblocker.hsts = require('./hsts.js');
 Unblocker.hpkp = require('./hpkp.js');
+Unblocker.csp = require('./csp.js');
 Unblocker.redirects = require('./redirects.js');
 Unblocker.decompress = require('./decompress.js');
 Unblocker.charsets = require('./charsets.js');
@@ -54,6 +55,7 @@ function Unblocker(config) {
         var cookies = Unblocker.cookies(config);
         var hsts = Unblocker.hsts(config);
         var hpkp = Unblocker.hpkp(config);
+        var csp = Unblocker.csp(config);
         var redirects = Unblocker.redirects(config);
         var decompress = Unblocker.decompress(config);
         var charsets = Unblocker.charsets(config);
@@ -71,6 +73,7 @@ function Unblocker(config) {
         config.responseMiddleware = [
             hsts,
             hpkp,
+            csp,
             redirects,
             decompress.handleResponse,
             charsets,

--- a/readme.md
+++ b/readme.md
@@ -177,6 +177,7 @@ Most of the internal functionality of the proxy is also implemented as middlewar
     Also injects redirects to copy cookies from between protocoles and subdomains on a given domain.
 * **hsts**: Removes [Strict-Transport-Security](https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security) headers because they can leak to other sites and can break the proxy.
 * **hpkp**: Removes [Public-Key-Pinning](https://en.wikipedia.org/wiki/HTTP_Public_Key_Pinning) headers because they can leak to other sites and can break the proxy.
+* **csp**: Removes [Content-Security-Policy](https://en.wikipedia.org/wiki/Content_Security_Policy) headers because they can leak to other sites and can break the proxy.
 * **redirects**: Rewrites urls in 3xx redirects to ensure they go through the proxy
 * **decompress**: Decompresses `Content-Encoding: gzip` responses and also tweaks request headers to ask for either gzip-only or no compression at all. (It will attempt to decompress `deflate` content, but there are some issues, so it does not advertise support for `deflate`.)
 * **charsets**: Converts the charset of responses to UTF-8 for safe string processing in node.js. Determines charset from headers or meta tags and rewrites all headers and meta tags in outgoing response.
@@ -210,6 +211,7 @@ var referer = Unblocker.referer(config);
 var cookies = Unblocker.cookies(config);
 var hsts = Unblocker.hsts(config);
 var hpkp = Unblocker.hpkp(config);
+var csp = Unblocker.csp(config);
 var redirects = Unblocker.redirects(config);
 var decompress = Unblocker.decompress(config);
 var charsets = Unblocker.charsets(config);
@@ -228,6 +230,7 @@ config.requestMiddleware = [
 config.responseMiddleware = [
     hsts,
     hpkp,
+    csp,
     redirects,
     decompress.handleResponse,
     charsets,


### PR DESCRIPTION
CSP is a technology used by many sites to prevent XSS.

GitHub uses it but it will cause issues in Unblocker if allowed to be used.

Reference: https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_Content_Security_Policy