### PR TITLE
Fix for really short HTML responses

### DIFF
--- a/lib/url-prefixer.js
+++ b/lib/url-prefixer.js
@@ -84,7 +84,7 @@ function urlPrefixer(config) {
                 // if we buffered a bit of text but we're now at the end of the data, then apparently
                 // it wasn't a url - send it along
                 if (chunk_remainder) {
-                    this.push(chunk_remainder);
+                    this.push(rewriteUrls(chunk_remainder, uri, config.prefix));
                     chunk_remainder = undefined;
                 }
                 done();


### PR DESCRIPTION
When HTML responses are short the flush function can sometimes get a chunk_remainder. Before the chunk_remainder is ignored. Now it parses the last piece to ensure that it will be parsed.

Notice that tweaking of `re_html_partial` could perhaps solve the issue.