### PR TITLE
 Fix for really short HTML responses

### DIFF
--- a/lib/url-prefixer.js
+++ b/lib/url-prefixer.js
@@ -84,7 +84,7 @@ function urlPrefixer(config) {
                 // if we buffered a bit of text but we're now at the end of the data, then apparently
                 // it wasn't a url - send it along
                 if (chunk_remainder) {
-                    this.push(chunk_remainder);
+                    this.push(rewriteUrls(chunk_remainder, uri, config.prefix));
                     chunk_remainder = undefined;
                 }
                 done();

--- a/test/expected/short.html
+++ b/test/expected/short.html
@@ -1,0 +1,1 @@
+<META HTTP-EQUIV="Refresh" CONTENT="0;URL=/proxy/http://example.com/example/path">

--- a/test/short_response_spec.js
+++ b/test/short_response_spec.js
@@ -1,0 +1,28 @@
+var fs = require('fs'),
+    concat = require('concat-stream'),
+    test = require('tap').test,
+    hyperquest = require('hyperquest'),
+    getServers = require('./test_utils.js').getServers;
+
+var source = fs.readFileSync(__dirname + '/source/short.html');
+var expected = fs.readFileSync(__dirname + '/expected/short.html');
+
+
+test("url_rewriting should support short html documents", function(t) {
+    getServers(source, function(err, servers) {
+        function cleanup() {
+            servers.kill(function() {
+                t.end();
+            });
+        }
+        hyperquest(servers.proxiedUrl)
+            .pipe(concat(function(data) {
+                t.equal(data.toString(), expected.toString().replace(/<remotePort>/g, servers.remotePort));
+                cleanup();
+            }))
+            .on('error', function(err) {
+                console.error('error retrieving data from proxy', err);
+                cleanup();
+            });
+    });
+});

--- a/test/source/short.html
+++ b/test/source/short.html
@@ -1,0 +1,1 @@
+<META HTTP-EQUIV="Refresh" CONTENT="0;URL=http://example.com/example/path">


### PR DESCRIPTION
When HTML responses are short the flush function can sometimes get a chunk_remainder. Before the chunk_remainder is ignored. Now it parses the last piece to ensure that it will be parsed.

Notice that tweaking of re_html_partial could perhaps solve the issue.

This includes tests. Close #86.
