### PR TITLE
Improved cookie rewriting

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -21,6 +21,31 @@ function cookies(config) {
 
     var REDIRECT_QUERY_PARAM = '__proxy_cookies_to';
 
+    // Serializes cookie without changing it
+    function serializeCookie(cookie) {
+        var str = cookie.name + '=' + cookie.value;
+
+        if (cookie.maxAge) {
+            str += '; Max-Age=' + cookie.maxAge;
+        }
+        if (cookie.domain) {
+            str += '; Domain=' + cookie.domain;
+        }
+        if (cookie.path) {
+            str += '; Path=' + cookie.path;
+        }
+        if (cookie.expires) {
+            str += '; Expires=' + cookie.expires.toUTCString();
+        }
+        if (cookie.httpOnly) {
+            str += '; HttpOnly';
+        }
+        if (cookie.secure) {
+            str += '; Secure';
+        }
+        return str;
+    }
+
     // normally we do nothing here, but when the user is switching protocols or subdomains, the handleResponse function
     // will rewrite the links to start with the old protocol & domain (so that we get sent the cookies), and then it
     // will copy the old cookies to the new path
@@ -63,7 +88,7 @@ function cookies(config) {
                 delete cookie.domain;
                 delete cookie.secure; // todo: maybe leave this if we knot the proxy is being accessed over https?
                 cookie.value = decodeURIComponent(cookie.value); // Used to avoid double percent-encoding
-                return libCookie.serialize(cookie.name, cookie.value, cookie);
+                return serializeCookie(cookie);
             });
         }
 

--- a/test/cookies_spec.js
+++ b/test/cookies_spec.js
@@ -67,6 +67,22 @@ test('should rewrite the cookie that is percent-encoded correctly', function(t) 
     t.end();
 });
 
+test('should rewrite the cookie that is weird but correct correctly', function(t) {
+    var instance = cookies({
+        prefix: '/proxy/',
+        processContentTypes: []
+    });
+    var data = getData();
+    data.headers['set-cookie'] = ['myCookie=is=called&john=doe&for=a&reason=#WeDontParseCookieValues&only=its&parameters=!; Path=/myAwesomePath; HttpOnly'];
+    instance.handleResponse(data);
+    var expected = [
+        'myCookie=is=called&john=doe&for=a&reason=#WeDontParseCookieValues&only=its&parameters=!; Path=/proxy/http://example.com/myAwesomePath; HttpOnly'
+    ];
+    var actual = data.headers['set-cookie'];
+    t.same(actual, expected);
+    t.end();
+});
+
 test("should copy any missing cookies to a 3xx redirect", function(t) {
     t.plan(1);
     var instance = cookies({


### PR DESCRIPTION
Includes test!

We should look into all the places where the libCookie.parse and libCookie.serialize is used to ensure that the value isn't changed. Probably better not to use it at all!