### PR TITLE
Fixing Zlib Error: unexpected end of file

### DIFF
--- a/lib/decompress.js
+++ b/lib/decompress.js
@@ -16,6 +16,12 @@ module.exports = function(config) {
     }
 
     function decompressResponse(data) {
+        // Status code 304 means content has not been changed, in this case there is no content
+        // https://httpstatuses.com/304
+        if ( data.remoteResponse.statusCode == 304) {
+            return;
+        }
+
         if (contentTypes.shouldProcess(config, data) && data.headers['content-encoding'] == 'gzip' || data.headers['content-encoding'] == 'deflate') {
             debug('decompressing %s encoding and deleting content-encoding header', data.headers['content-encoding']);
             if (data.headers['content-encoding'] == 'deflate') {


### PR DESCRIPTION
In case of status code return from the external website/request is 304, meaning there has been no change in the content, there is no content in the body of response. And passing that stream through Zlib causes error "unexpected end of file".  Hence checking for status code 304 before passing it through Zlib solves the problem