### PR TITLE
Fix syntax errors in examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,7 +109,7 @@ If you're using express, the request and response objects will have all of the u
 
 ```js
 function validateRequest(data) {
-    if (!data.url.match(/^https?:\/\/en.wikipedia.org\//) {
+    if (!data.url.match(/^https?:\/\/en.wikipedia.org\//)) {
         data.clientResponse.status(403).send('Wikipedia only.');
     }
 }
@@ -159,6 +159,7 @@ function injectScript(data) {
                 chunk = chunk.toString.replace('</body>', '<script src="/my/script.js"></script></body>');
                 this.push(chunk);
                 next();
+                }
         });
 
         data.stream = data.stream.pipe(myStream);


### PR DESCRIPTION
The examples had simple syntax errors, such as a missing paren or bracket.