### PR TITLE
Write meta robots only when content type is HTML.

### DIFF
--- a/lib/meta-robots.js
+++ b/lib/meta-robots.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
 
     function metaRobots(data) {
         // this leaks to all sites that are visited by the client & it can block the client from accessing the proxy if https is not avaliable.
-        if (contentTypes.shouldProcess(config, data)) {
+        if (contentTypes.html.indexOf(data.contentType) != -1) {
             data.stream = data.stream.pipe(createStream());
         }
     }


### PR DESCRIPTION
As of current, the metaRobots middleware uses check `contentTypes.shouldProcess`. But this could be an issue often a times when user includes other content types in `config.processContentTypes` such as Javascript containing string of HTML with `'</head>'` string and this way the Javascript file gets rewritten incorrectly.

I think that the metaRobots middleware is only required over HTML content type. This PR drops the use of contentTypes.shouldProcess check and explicitly checks if content type is HTML.