### PR TITLE
Ignore trailing backslash from URLs.

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -112,7 +112,7 @@ function cookies(config) {
         if (contentTypes.shouldProcess(config, data)) {
 
             var tld = TLD.registered(uri.hostname);
-            var RE_PROTO_SUBDOMAIN_URL = new RegExp(config.prefix + "(https?://([a-z0-9.-]+\.)?" + tld + "[^'\") ]*)", "ig");
+            var RE_PROTO_SUBDOMAIN_URL = new RegExp(config.prefix + "(https?://([a-z0-9.-]+\.)?" + tld + "[^'\") \\\\]*)", "ig");
 
             data.stream = data.stream.pipe(new Transform({
                 decodeStrings: false,

--- a/test/cookies_spec.js
+++ b/test/cookies_spec.js
@@ -112,6 +112,7 @@ test('should rewrite urls that change subdomain or protocol (but not domain)', f
         '<a href="/proxy/http://sub.example.com/">new subdomain</a>',
         '<a href="/proxy/http://othersite.com/">other site, same proto</a>',
         '<a href="/proxy/https://othersite.com/">other site, dif proto</a>',
+        '<a href="javascript:void(0)" onclick="window.open(\'/proxy/http://sub.example.com/\')">new subdomain using inline JS</a>',
         '<img src="/proxy/http://example.com/img.jpg" alt="no change" />',
         '<img src="/proxy/https://example.com/img.jpg" alt="new proto">'
     ].join('\n');
@@ -122,6 +123,7 @@ test('should rewrite urls that change subdomain or protocol (but not domain)', f
         '<a href="/proxy/http://example.com/?__proxy_cookies_to=http%3A%2F%2Fsub.example.com%2F">new subdomain</a>',
         '<a href="/proxy/http://othersite.com/">other site, same proto</a>',
         '<a href="/proxy/https://othersite.com/">other site, dif proto</a>',
+        '<a href="javascript:void(0)" onclick="window.open(\'/proxy/http://example.com/?__proxy_cookies_to=http%3A%2F%2Fsub.example.com%2F\')">new subdomain using inline JS</a>',
         '<img src="/proxy/http://example.com/img.jpg" alt="no change" />',
         '<img src="/proxy/http://example.com/img.jpg?__proxy_cookies_to=https%3A%2F%2Fexample.com%2Fimg.jpg" alt="new proto">'
     ].join('\n');


### PR DESCRIPTION
For instance when this Javascript passes through the cookies middleware and URL appears to be changing subdomain or protocol, the `RE_PROTO_SUBDOMAIN_URL` regex will strip the trailing backslash from the URL part which is actually supposed to be escape character of `'`.
```js
document.write('<a href="javascript:void(0)" onclick="window.open(\'/proxy/http://www.hdfcbank.com/htdocs/common/onlineservices/netbankingdemo/index.html\')" style="vertical-align: middle;position: relative;top: 4px;">View Demo</a>');
document.write('<span class="content nb_link">');
```

And the above URL part within window.open gets rewritten to:
 ```js
document.write('<a href="javascript:void(0)" onclick="window.open(\'/proxy/https://netbanking.hdfcbank.com/htdocs/common/onlineservices/netbankingdemo/index.html?__proxy_cookies_to=http%3A%2F%2Fwww.hdfcbank.com%2Fhtdocs%2Fcommon%2Fonlineservices%2Fnetbankingdemo%2Findex.html')" style="vertical-align: middle;position: relative;top: 4px;">View Demo</a>');
document.write('<span class="content nb_link">');
```

### Expected:
URL within `window.open(\'...\')` statement containing properly escaped quotes.
 ```js
document.write('<a href="javascript:void(0)" onclick="window.open(\'/proxy/https://netbanking.hdfcbank.com/htdocs/common/onlineservices/netbankingdemo/index.html?__proxy_cookies_to=http%3A%2F%2Fwww.hdfcbank.com%2Fhtdocs%2Fcommon%2Fonlineservices%2Fnetbankingdemo%2Findex.html\')" style="vertical-align: middle;position: relative;top: 4px;">View Demo</a>');
document.write('<span class="content nb_link">');
```

For regex reference: https://regex101.com/r/x4AHUz/1